### PR TITLE
Allow SuppressNullableWarningExpression for required Args/Opts

### DIFF
--- a/src/DotMake.CommandLine.SourceGeneration/CliArgumentInfo.cs
+++ b/src/DotMake.CommandLine.SourceGeneration/CliArgumentInfo.cs
@@ -45,8 +45,10 @@ namespace DotMake.CommandLine.SourceGeneration
                 && requiredTypedConstant.Value != null)
                 Required = (bool)requiredTypedConstant.Value;
             else
-                Required = (SyntaxNode is PropertyDeclarationSyntax propertyDeclarationSyntax
-                            && propertyDeclarationSyntax.Initializer == null);
+                Required = (SyntaxNode is PropertyDeclarationSyntax propertyDeclarationSyntax && (
+                                propertyDeclarationSyntax.Initializer == null
+                                || propertyDeclarationSyntax.Initializer.Value.IsKind(SyntaxKind.SuppressNullableWarningExpression)
+                            ));
         }
 
         public CliArgumentInfo(GeneratorAttributeSyntaxContext attributeSyntaxContext)

--- a/src/DotMake.CommandLine.SourceGeneration/CliOptionInfo.cs
+++ b/src/DotMake.CommandLine.SourceGeneration/CliOptionInfo.cs
@@ -50,8 +50,11 @@ namespace DotMake.CommandLine.SourceGeneration
                 && requiredTypedConstant.Value != null)
                 Required = (bool)requiredTypedConstant.Value;
             else
-                Required = (SyntaxNode is PropertyDeclarationSyntax propertyDeclarationSyntax
-                            && propertyDeclarationSyntax.Initializer == null);
+                Required = (SyntaxNode is PropertyDeclarationSyntax propertyDeclarationSyntax && (
+                                propertyDeclarationSyntax.Initializer == null
+                                || propertyDeclarationSyntax.Initializer.Value.IsKind(SyntaxKind.SuppressNullableWarningExpression)
+                            ));
+            
         }
 
         public CliOptionInfo(GeneratorAttributeSyntaxContext attributeSyntaxContext)

--- a/src/TestApp/Commands/NullableReferenceCommand.cs
+++ b/src/TestApp/Commands/NullableReferenceCommand.cs
@@ -16,8 +16,20 @@ namespace TestApp.Commands
         )]
         public string? Display { get; set; } //= "test";
 
+        [CliOption(
+            Description = "Description for Display2",
+            AllowedValues = new[] { "Big", "Small" }
+        )]
+        public string Display2 { get; set; } = null!;
+
         [CliArgument(Required = false)]
         public string[]? NullableRefArg { get; set; } //= new[] { "1", "2" };
+
+        [CliOption]
+        public string ReqOption { get; set; } = null!;
+
+        [CliArgument]
+        public string ReqArg { get; set; } = null!;
 
         public void Run(InvocationContext context)
         {

--- a/src/TestApp/GeneratedFiles/net472/DotMake.CommandLine.SourceGeneration/DotMake.CommandLine.SourceGeneration.CliCommandGenerator/NullableReferenceCommandBuilder-b94mnm0.g.cs
+++ b/src/TestApp/GeneratedFiles/net472/DotMake.CommandLine.SourceGeneration/DotMake.CommandLine.SourceGeneration.CliCommandGenerator/NullableReferenceCommandBuilder-b94mnm0.g.cs
@@ -51,6 +51,37 @@ namespace TestApp.Commands
             option0.AddAlias("-d");
             rootCommand.Add(option0);
 
+            // Option for 'Display2' property
+            var option1 = new System.CommandLine.Option<string>
+            (
+                "--display-2",
+                GetParseArgument<string>
+                (
+                    null
+                )
+            )
+            {
+                Description = "Description for Display2",
+                IsRequired = true,
+            };
+            System.CommandLine.OptionExtensions.FromAmong(option1, new[] {"Big", "Small"});
+            rootCommand.Add(option1);
+
+            // Option for 'ReqOption' property
+            var option2 = new System.CommandLine.Option<string>
+            (
+                "--req",
+                GetParseArgument<string>
+                (
+                    null
+                )
+            )
+            {
+                IsRequired = true,
+            };
+            option2.AddAlias("-r");
+            rootCommand.Add(option2);
+
             // Argument for 'NullableRefArg' property
             var argument0 = new System.CommandLine.Argument<string[]>
             (
@@ -66,6 +97,19 @@ namespace TestApp.Commands
             argument0.SetDefaultValue(defaultClass.NullableRefArg);
             rootCommand.Add(argument0);
 
+            // Argument for 'ReqArg' property
+            var argument1 = new System.CommandLine.Argument<string>
+            (
+                "req-arg",
+                GetParseArgument<string>
+                (
+                    null
+                )
+            )
+            {
+            };
+            rootCommand.Add(argument1);
+
             // Add nested or external registered children
             foreach (var child in Children)
             {
@@ -78,9 +122,12 @@ namespace TestApp.Commands
 
                 //  Set the parsed or default values for the options
                 targetClass.Display = GetValueForOption(parseResult, option0);
+                targetClass.Display2 = GetValueForOption(parseResult, option1);
+                targetClass.ReqOption = GetValueForOption(parseResult, option2);
 
                 //  Set the parsed or default values for the arguments
                 targetClass.NullableRefArg = GetValueForArgument(parseResult, argument0);
+                targetClass.ReqArg = GetValueForArgument(parseResult, argument1);
 
                 return targetClass;
             };

--- a/src/TestApp/GeneratedFiles/net6.0/DotMake.CommandLine.SourceGeneration/DotMake.CommandLine.SourceGeneration.CliCommandGenerator/NullableReferenceCommandBuilder-b94mnm0.g.cs
+++ b/src/TestApp/GeneratedFiles/net6.0/DotMake.CommandLine.SourceGeneration/DotMake.CommandLine.SourceGeneration.CliCommandGenerator/NullableReferenceCommandBuilder-b94mnm0.g.cs
@@ -51,6 +51,37 @@ namespace TestApp.Commands
             option0.AddAlias("-d");
             rootCommand.Add(option0);
 
+            // Option for 'Display2' property
+            var option1 = new System.CommandLine.Option<string>
+            (
+                "--display-2",
+                GetParseArgument<string>
+                (
+                    null
+                )
+            )
+            {
+                Description = "Description for Display2",
+                IsRequired = true,
+            };
+            System.CommandLine.OptionExtensions.FromAmong(option1, new[] {"Big", "Small"});
+            rootCommand.Add(option1);
+
+            // Option for 'ReqOption' property
+            var option2 = new System.CommandLine.Option<string>
+            (
+                "--req",
+                GetParseArgument<string>
+                (
+                    null
+                )
+            )
+            {
+                IsRequired = true,
+            };
+            option2.AddAlias("-r");
+            rootCommand.Add(option2);
+
             // Argument for 'NullableRefArg' property
             var argument0 = new System.CommandLine.Argument<string[]>
             (
@@ -66,6 +97,19 @@ namespace TestApp.Commands
             argument0.SetDefaultValue(defaultClass.NullableRefArg);
             rootCommand.Add(argument0);
 
+            // Argument for 'ReqArg' property
+            var argument1 = new System.CommandLine.Argument<string>
+            (
+                "req-arg",
+                GetParseArgument<string>
+                (
+                    null
+                )
+            )
+            {
+            };
+            rootCommand.Add(argument1);
+
             // Add nested or external registered children
             foreach (var child in Children)
             {
@@ -78,9 +122,12 @@ namespace TestApp.Commands
 
                 //  Set the parsed or default values for the options
                 targetClass.Display = GetValueForOption(parseResult, option0);
+                targetClass.Display2 = GetValueForOption(parseResult, option1);
+                targetClass.ReqOption = GetValueForOption(parseResult, option2);
 
                 //  Set the parsed or default values for the arguments
                 targetClass.NullableRefArg = GetValueForArgument(parseResult, argument0);
+                targetClass.ReqArg = GetValueForArgument(parseResult, argument1);
 
                 return targetClass;
             };


### PR DESCRIPTION
Nice library!!!! Thanks for your work!!!!!!

In my projects i use broadly nullable check enabled.
Trying your library, i found a minor issue for models with a "required" property (from C# point of view): if I use the fake null/bang initializer to suppress the not null warning, I'm forced to put `Required = true` attribute...

```
[CliCommand]
public class MyCommand
{
    [CliArgument(Required = true)]  //Required=true is necessary to make the argument required for command-line
    public string MyArg { get; set; } = null!; // =null! is necessary to suppress the compiler warning because property is not nullable
}
```

With this PR is possible to work with default convention and remove the `Required=true` in the attribute
```
[CliCommand]
public class MyCommand
{
    [CliArgument]
    public string MyArg { get; set; } = null!; // =null! is necessary to suppress the compiler warning because property is not nullable
}
```

P.S. probably the "ideal" for modern C# is to allow a syntax like this:
```
[CliCommand]
public class MyCommand
{
    [CliArgument]
    public required string MyArg { get; set; } 
}
```
but to allow this to work the generated code becomes more complex.... 




