### PR TITLE
Improve exceptions for incorrect usage of "CliCommand"

### DIFF
--- a/src/DotMake.CommandLine.Shared/Exceptions/InvalidClassException.cs
+++ b/src/DotMake.CommandLine.Shared/Exceptions/InvalidClassException.cs
@@ -1,4 +1,4 @@
-namespace DotMake.CommandLine.Shared;
+namespace DotMake.CommandLine;
 
 public class InvalidClassException : System.Exception
 {

--- a/src/DotMake.CommandLine.Shared/Exceptions/InvalidClassException.cs
+++ b/src/DotMake.CommandLine.Shared/Exceptions/InvalidClassException.cs
@@ -1,4 +1,4 @@
-namespace DotMake.CommandLine.Shared.Exceptions;
+namespace DotMake.CommandLine.Shared;
 
 public class InvalidClassException : System.Exception
 {

--- a/src/DotMake.CommandLine.Shared/Exceptions/InvalidClassException.cs
+++ b/src/DotMake.CommandLine.Shared/Exceptions/InvalidClassException.cs
@@ -1,0 +1,7 @@
+namespace DotMake.CommandLine.Shared.Exceptions;
+
+public class InvalidClassException : System.Exception
+{
+    public InvalidClassException() : base("An invalid class was passed to the 'Run<T>' method. Please ensure the class is a 'CliCommand'.")
+    public InvalidClassException(string message) : base(message) { }
+}

--- a/src/DotMake.CommandLine.Shared/Exceptions/InvalidParentClassException.cs
+++ b/src/DotMake.CommandLine.Shared/Exceptions/InvalidParentClassException.cs
@@ -1,0 +1,7 @@
+namespace DotMake.CommandLine.Shared.Exceptions;
+
+public class InvalidParentClassException : System.Exception
+{
+    public InvalidParentClassException() : base("The 'CliCommand' passed to the 'Run<T>' method is inside of a class that is invalid. Please ensure the parent class is also a 'CliCommand'.");
+    public InvalidParentClassException(string message) : base(message);
+}

--- a/src/DotMake.CommandLine.Shared/Exceptions/InvalidParentClassException.cs
+++ b/src/DotMake.CommandLine.Shared/Exceptions/InvalidParentClassException.cs
@@ -1,4 +1,4 @@
-namespace DotMake.CommandLine.Shared.Exceptions;
+namespace DotMake.CommandLine.Shared;
 
 public class InvalidParentClassException : System.Exception
 {

--- a/src/DotMake.CommandLine.Shared/Exceptions/InvalidParentClassException.cs
+++ b/src/DotMake.CommandLine.Shared/Exceptions/InvalidParentClassException.cs
@@ -1,4 +1,4 @@
-namespace DotMake.CommandLine.Shared;
+namespace DotMake.CommandLine;
 
 public class InvalidParentClassException : System.Exception
 {

--- a/src/DotMake.CommandLine/Cli.cs
+++ b/src/DotMake.CommandLine/Cli.cs
@@ -111,7 +111,7 @@ namespace DotMake.CommandLine
                 var versionOption = new VersionOption(
                     "version".AddPrefix(commandBuilder.NamePrefixConvention),
                     commandBuilder.ShortFormAutoGenerate
-                        ? new []{ "v".AddPrefix(commandBuilder.ShortFormPrefixConvention) }
+                        ? new[] { "v".AddPrefix(commandBuilder.ShortFormPrefixConvention) }
                         : Array.Empty<string>()
                 )
                 {
@@ -323,6 +323,15 @@ namespace DotMake.CommandLine
                 parseResult.Configuration.Output.WriteLine(ExecutableInfo.Version);
                 return 0;
             }
+        }
+
+        /// <summary>
+        /// Ensures that a TDefinition is valid to be run as a command.
+        /// </summary>
+        /// <typeparam name="TDefinition">The TDefinition to be checked.</typeparam>
+        private static void EnsureValidityForCommand<TDefinition>()
+        {
+            
         }
     }
 }

--- a/src/DotMake.CommandLine/Cli.cs
+++ b/src/DotMake.CommandLine/Cli.cs
@@ -111,7 +111,7 @@ namespace DotMake.CommandLine
                 var versionOption = new VersionOption(
                     "version".AddPrefix(commandBuilder.NamePrefixConvention),
                     commandBuilder.ShortFormAutoGenerate
-                        ? new[] { "v".AddPrefix(commandBuilder.ShortFormPrefixConvention) }
+                        ? new []{ "v".AddPrefix(commandBuilder.ShortFormPrefixConvention) }
                         : Array.Empty<string>()
                 )
                 {


### PR DESCRIPTION
Fixes #11 

I made a simple draft creating the exceptions in the `DotMake.CommandLine.Shared` project. What do you think of them?

Please review the naming and messages I made.