### PR TITLE
Handle platform-specific default color for background & foreground properly

### DIFF
--- a/src/DotMake.CommandLine/CliTheme.cs
+++ b/src/DotMake.CommandLine/CliTheme.cs
@@ -12,7 +12,7 @@ namespace DotMake.CommandLine
         /// </summary>
         public CliTheme()
         {
-            
+
         }
 
         /// <summary>
@@ -33,13 +33,13 @@ namespace DotMake.CommandLine
 
         /// <summary>
         /// Gets or sets the default color used by the app.
-        /// <para>Default is <see langword="null"/> which also means <see cref="ConsoleColor.Gray"/>.</para>
+        /// <para>Default is <see langword="null"/>, which is equivalent to <see cref="ConsoleColor.Gray"/> on Windows. On *nix-like platforms, the default is unset (<see cref="ConsoleColor"/>(-1)).</para>
         /// </summary>
         public ConsoleColor? DefaultColor { get; init; }
 
         /// <summary>
         /// Gets or sets the default background color used by the app.
-        /// <para>Default is <see langword="null"/> which also means <see cref="ConsoleColor.Black"/>.</para>
+        /// <para>Default is <see langword="null"/>, which is equivalent to <see cref="ConsoleColor.Black"/> on Windows. On *nix-like platforms, the default is unset (<see cref="ConsoleColor"/>(-1)).</para>
         /// </summary>
         public ConsoleColor? DefaultBgColor { get; init; }
 
@@ -101,7 +101,7 @@ namespace DotMake.CommandLine
         /// <para>First column is similar to:</para>
         /// <code language="console">
         ///   &lt;argument-1&gt;
-        /// 
+        ///
         ///   -o, --option-1 &lt;option-1&gt;
         ///   -v, --version
         ///   -?, -h, --help
@@ -117,7 +117,7 @@ namespace DotMake.CommandLine
         /// <para>Second column is similar to:</para>
         /// <code language="console">
         ///                       Description for Argument1 [required]
-        /// 
+        ///
         ///                       Description for Option1 [default: DefaultForOption1]
         ///                       Show version information
         ///                       Show help and usage information

--- a/src/DotMake.CommandLine/ConsoleExtensions.cs
+++ b/src/DotMake.CommandLine/ConsoleExtensions.cs
@@ -21,10 +21,9 @@ namespace DotMake.CommandLine
         {
             if (ColorIsSupported && !Console.IsOutputRedirected)
             {
-                //Color 07 will set it to the default scheme that cmd.exe uses.
-                //0 = Black
-                //7 = White  (ConsoleColor.Gray is 7)
-                //https://superuser.com/a/158769
+                // https://learn.microsoft.com/en-us/dotnet/api/system.console.foregroundcolor?view=net-8.0#remarks
+                // On Windows, the default color is gray (ConsoleColor.Gray).
+                // On *nix-like platforms, the default color is unset ((ConsoleColor)-1).
                 if (color == null)
                     Console.ForegroundColor = defaultColor ?? ConsoleColor.Gray;
                 else
@@ -36,12 +35,12 @@ namespace DotMake.CommandLine
         {
             if (ColorIsSupported && !Console.IsOutputRedirected)
             {
-                //Color 07 will set it to the default scheme that cmd.exe uses.
-                //0 = Black
-                //7 = White  (ConsoleColor.Gray is 7)
-                //https://superuser.com/a/158769
+                // https://learn.microsoft.com/en-us/dotnet/api/system.console.backgroundcolor?view=net-8.0#remarks
+                // On Windows, the default color is black (ConsoleColor.Black).
+                // On *nix-like platforms, the default color is unset ((ConsoleColor)-1).
                 if (color == null)
-                    Console.BackgroundColor = defaultColor ?? ConsoleColor.Black;
+                    // Console.BackgroundColor = defaultColor ?? ConsoleColor.Black;
+                    Console.BackgroundColor = defaultColor ?? (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? ConsoleColor.Black : (ConsoleColor)(-1));
                 else
                     Console.BackgroundColor = color.Value;
             }


### PR DESCRIPTION
The current configuration has a noticeable issue where using the default cli theme that the background color is always black on *nix platforms, whateve the terminal background color is, e.g:

![image](https://github.com/user-attachments/assets/1d9ec398-4263-4a00-a7c4-f3e420942aea)


Currently, the default values for foreground and background colors are based on the Windows configuration. However, on *nix platforms, the situation is different; an explicit value is not set, and the value remains -1 until the application specifies one.

Based on the relevent documentations, I adjusted the default value based on the platform info.
https://learn.microsoft.com/en-us/dotnet/api/system.console.backgroundcolor?view=net-8.0#remarks
https://learn.microsoft.com/en-us/dotnet/api/system.console.foregroundcolor?view=net-8.0#remarks

![image](https://github.com/user-attachments/assets/ec2c547f-d060-4cc6-83e3-c51d8f41b727)


