### PR TITLE
Fix EnumUtil to Generate Multiple Flags if Necessary

### DIFF
--- a/src/DotMake.CommandLine.SourceGeneration/Util/EnumUtil.cs
+++ b/src/DotMake.CommandLine.SourceGeneration/Util/EnumUtil.cs
@@ -6,6 +6,7 @@ namespace DotMake.CommandLine.SourceGeneration.Util
 {
     public static class EnumUtil<TEnum> where TEnum : Enum
     {
+        private static readonly bool IsFlagsEnum = typeof(TEnum).IsDefined(typeof(FlagsAttribute), false);
         private static readonly Dictionary<TEnum, EnumInfo> Cache;
 
         static EnumUtil()
@@ -25,9 +26,23 @@ namespace DotMake.CommandLine.SourceGeneration.Util
 
         public static string ToFullName(TEnum value)
         {
-            return Cache.TryGetValue(value, out var enumInfo)
-                ? enumInfo.FullName
-                : string.Empty;
+            var fullName = string.Empty;
+
+            if (Cache.TryGetValue(value, out var enumInfo))
+            {
+                fullName = enumInfo.FullName;
+            }
+            else if (IsFlagsEnum)
+            {
+                var flags =
+                    Cache.Values
+                        .Where(x => !EqualityComparer<TEnum>.Default.Equals(x.Value, default) && value.HasFlag(x.Value))
+                        .Select(x => x.FullName);
+
+                fullName = string.Join(" | ", flags);
+            }
+
+            return fullName;
         }
 
         public static IEnumerable<EnumInfo> Enumerate()


### PR DESCRIPTION
Allows Specifying Multiple Enum Flags for Cli Attributes with `Flags` Enum properties. Resolves #35

Use case example

```c#
[CliCommand(
    Description = "A root cli command", 
    ShortFormAutoGenerate = CliNameAutoGenerate.Options | CliNameAutoGenerate.Arguments)]
public class RootHelpOnEmptyCliCommand
{
    [CliOption(Description = "Description for Option1")]
    public string Option1 { get; set; } = "DefaultForOption1";

    [CliArgument(Description = "Description for Argument1")]
    public string Argument1 { get; set; } = "DefaultForArgument1";

    public void Run(CliContext context)
    {
        if (context.IsEmptyCommand())
            context.ShowHelp();
        else
            context.ShowValues();
    }
}
```

Produces Source Generated Constructor

```c#
public RootHelpOnEmptyCliCommandBuilder()
{
    DefinitionType = typeof(TestApp.Commands.RootHelpOnEmptyCliCommand);
    ParentDefinitionType = null;
    ChildDefinitionTypes = null;
    NameAutoGenerate = null;
    NameCasingConvention = null;
    NamePrefixConvention = null;
    ShortFormAutoGenerate = DotMake.CommandLine.CliNameAutoGenerate.Options | DotMake.CommandLine.CliNameAutoGenerate.Arguments;
    ShortFormPrefixConvention = null;
}
``` 