### PR TITLE
Set RootCommand first allowing options to reference RootCommand

### DIFF
--- a/src/DotMake.CommandLine.SourceGeneration/Outputs/CliCommandOutput.cs
+++ b/src/DotMake.CommandLine.SourceGeneration/Outputs/CliCommandOutput.cs
@@ -273,6 +273,15 @@ namespace DotMake.CommandLine.SourceGeneration.Outputs
                         sb.AppendLine($"var {varTargetClass} = CreateInstance();");
 
                         sb.AppendLine();
+                        sb.AppendLine("//  Set the values for the parent command accessors");
+                        foreach (var cliParentCommandAccessorInfo in parentCommandAccessorsWithoutProblem)
+                        {
+                            sb.AppendLine($"{varTargetClass}.{cliParentCommandAccessorInfo.Symbol.Name} = DotMake.CommandLine.ParseResultExtensions");
+                            sb.AppendIndent();
+                            sb.AppendLine($".Bind<{cliParentCommandAccessorInfo.Symbol.Type.ToReferenceString()}>({varParseResult});");
+                        }
+
+                        sb.AppendLine();
                         sb.AppendLine("//  Set the parsed or default values for the directives");
                         for (var index = 0; index < directivesWithoutProblem.Length; index++)
                         {
@@ -297,15 +306,6 @@ namespace DotMake.CommandLine.SourceGeneration.Outputs
                             var cliArgumentInfo = argumentsWithoutProblem[index];
                             var varArgument = $"argument{index}";
                             sb.AppendLine($"{varTargetClass}.{cliArgumentInfo.Symbol.Name} = GetValueForArgument({varParseResult}, {varArgument});");
-                        }
-
-                        sb.AppendLine();
-                        sb.AppendLine("//  Set the values for the parent command accessors");
-                        foreach (var cliParentCommandAccessorInfo in parentCommandAccessorsWithoutProblem)
-                        {
-                            sb.AppendLine($"{varTargetClass}.{cliParentCommandAccessorInfo.Symbol.Name} = DotMake.CommandLine.ParseResultExtensions");
-                            sb.AppendIndent();
-                            sb.AppendLine($".Bind<{cliParentCommandAccessorInfo.Symbol.Type.ToReferenceString()}>({varParseResult});");
                         }
 
                         sb.AppendLine();
@@ -397,7 +397,7 @@ namespace DotMake.CommandLine.SourceGeneration.Outputs
             {
                 //Cannot set name for a RootCommand, it's the executable name by default
                 sb.AppendLine($"? new {CommandClassNamespace}.{RootCommandClassName}()");
-                sb.AppendLine($": new {CommandClassNamespace}.{CommandClassName}({varNameParameter});");                
+                sb.AppendLine($": new {CommandClassNamespace}.{CommandClassName}({varNameParameter});");
             }
 
             sb.AppendLine($"var {varRootName} = {varName} as {CommandClassNamespace}.{RootCommandClassName};");


### PR DESCRIPTION
This is just an example PR, I was unable to get the forked project to compile, and thus unable to to test it.

There is no support for VSCode, had to use Visual Studio.\
The SLN fails to build complaining about missing publish directories.\
The SLN fails to restore dependencies.\
There is no github actions or other CI/CD tooling to use to test builds.\
The CMD files seem very Windows specific and does not work in Linux.\
There is no build instructions to help.