### PR TITLE
Fix issue #71 (Syntax node is not within syntax tree)

### DIFF
--- a/src/DotMake.CommandLine.SourceGeneration/Util/AttributeArguments.cs
+++ b/src/DotMake.CommandLine.SourceGeneration/Util/AttributeArguments.cs
@@ -101,7 +101,13 @@ namespace DotMake.CommandLine.SourceGeneration.Util
                 {
                     var nameofArgument = invocationExpressionSyntax.ArgumentList.Arguments[0].Expression;
 
-                    if (semanticModel.GetSymbolInfo(nameofArgument).Symbol is IPropertySymbol propertySymbol
+                    // fix #71: Syntax node is not within syntax tree
+                    var correctModel = semanticModel.Compilation.GetSemanticModel(nameofArgument.SyntaxTree);
+
+                    SymbolInfo nameofInfo;
+                    nameofInfo = correctModel.GetSymbolInfo(nameofArgument);
+
+                    if (nameofInfo.Symbol is IPropertySymbol propertySymbol
                         && propertySymbol.Type.SpecialType == SpecialType.System_String)
                     {
                         var classAttributeData = propertySymbol.ContainingType.GetAttributes()

--- a/src/TestApp/Commands/LocalizedCliBaseCommand.cs
+++ b/src/TestApp/Commands/LocalizedCliBaseCommand.cs
@@ -1,0 +1,17 @@
+using DotMake.CommandLine;
+
+namespace TestApp.Commands
+{
+    #region LocalizedCliCommand
+
+    // used to test that the properties in the base class are also localized when the derived class is localized by using `nameof` operator with resource properties in the attributes.
+    //it is located in separate file to be sure  that issue#71 is fixed
+    internal class LocalizedCliBaseCommand
+    {
+        [CliOption(Description = nameof(TestResources.BaseOptionDescription))]
+        public string BaseOption { get; set; } = "DefaultForBaseOption";
+       
+    }
+
+    #endregion
+}

--- a/src/TestApp/Commands/LocalizedCliCommand.cs
+++ b/src/TestApp/Commands/LocalizedCliCommand.cs
@@ -10,9 +10,10 @@ namespace TestApp.Commands
     // If the property in the `nameof` operator expression does not point to a resource property, then the name of that property will be used as usual.
     // The reason we use `nameof` operator is that attributes in `.NET` only accept compile-time constants and you get `CS0182` error if not,
     // so specifying resource property directly is not possible as it's not a compile-time constant but it's a static property access.
-    
+    // LocalizedCliBaseCommand is located in a separate file to be sure that issue#71 is fixed.
+
     [CliCommand(Description = nameof(TestResources.CommandDescription))]
-    internal class LocalizedCliCommand
+    internal class LocalizedCliCommand : LocalizedCliBaseCommand
     {
         [CliOption(Description = nameof(TestResources.OptionDescription))]
         public string Option1 { get; set; } = "DefaultForOption1";

--- a/src/TestApp/Program.cs
+++ b/src/TestApp/Program.cs
@@ -15,7 +15,7 @@ using TestApp.Commands.PrefixConvention;
 
 
 //Using Cli.Run with class:
-Cli.Run<RootHelpOnEmptyCliCommand>(args);
+//Cli.Run<RootHelpOnEmptyCliCommand>(args);
 //Cli.Run<RootCliCommand>(args);
 //Cli.Run<WriteFileCliCommand>(args);
 //Cli.Run<ArgumentConverterCliCommand>(args);
@@ -26,7 +26,7 @@ Cli.Run<RootHelpOnEmptyCliCommand>(args);
 //Cli.Run<RootAsExternalParentCliCommand>(args);
 //Cli.Run<RootWithMixedChildrenCliCommand>(args);
 //Cli.Run<InheritanceCliCommand>(args);
-//Cli.Run<LocalizedCliCommand>(args);
+Cli.Run<LocalizedCliCommand>(args);
 //Cli.Run<HelpCliCommand>(args);
 //Cli.Run<ValidationCliCommand>(args);
 //Cli.Run<InvalidCliCommand>(args);

--- a/src/TestApp/TestResources.Designer.cs
+++ b/src/TestApp/TestResources.Designer.cs
@@ -19,7 +19,7 @@ namespace TestApp {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "17.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "18.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class TestResources {
@@ -66,6 +66,15 @@ namespace TestApp {
         internal static string ArgumentDescription {
             get {
                 return ResourceManager.GetString("ArgumentDescription", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Localized description for Base Option from resource (resx).
+        /// </summary>
+        internal static string BaseOptionDescription {
+            get {
+                return ResourceManager.GetString("BaseOptionDescription", resourceCulture);
             }
         }
         

--- a/src/TestApp/TestResources.resx
+++ b/src/TestApp/TestResources.resx
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <root>
   <!-- 
     Microsoft ResX Schema 
@@ -119,6 +119,9 @@
   </resheader>
   <data name="ArgumentDescription" xml:space="preserve">
     <value>Localized description for Argument from resource (resx)</value>
+  </data>
+  <data name="BaseOptionDescription" xml:space="preserve">
+    <value>Localized description for Base Option from resource (resx)</value>
   </data>
   <data name="CommandDescription" xml:space="preserve">
     <value>Localized description for Command from resource (resx)</value>


### PR DESCRIPTION
Fix Issue (#71)(Localization does not work for commands in separate files ) due to `Syntax node is not within syntax tree` by correcting the syntax tree.
Now Localization with inherited classes that are exist in different file  and is using resources  is working fine.
 